### PR TITLE
Suggest addition to the skims

### DIFF
--- a/AnalysisTree/test/produceLLGEvents.cc
+++ b/AnalysisTree/test/produceLLGEvents.cc
@@ -184,6 +184,7 @@ bool LooperFunctionHelpers::looperRule(BaseTreeLooper* theLooper, double const& 
   BRANCH_COMMAND(float, photon_full5x5_sigmaIEtaIEta) \
   BRANCH_COMMAND(float, photon_full5x5_sigmaIPhiIPhi) \
   BRANCH_COMMAND(float, photon_full5x5_r9) \
+  BRANCH_COMMAND(float, photon_r9) \
   BRANCH_COMMAND(float, photon_seedTime) \
   BRANCH_COMMAND(float, photon_MIPTotalEnergy) \
   BRANCH_COMMAND(bool, photon_is_genMatched_prompt) \
@@ -332,6 +333,7 @@ bool LooperFunctionHelpers::looperRule(BaseTreeLooper* theLooper, double const& 
   if (!theChosenPhoton || n_photons_veto!=0) return false;
 
   photon_pt = theChosenPhoton->pt();
+  if (!OffshellCutflow::check_pTll(photon_pt)) return false; // Skim photons below the pTll threshold
   photon_eta = theChosenPhoton->eta();
   photon_phi = theChosenPhoton->phi();
   photon_mass = theChosenPhoton->m();
@@ -350,6 +352,7 @@ bool LooperFunctionHelpers::looperRule(BaseTreeLooper* theLooper, double const& 
   photon_full5x5_sigmaIEtaIEta = theChosenPhoton->extras.full5x5_sigmaIEtaIEta;
   photon_full5x5_sigmaIPhiIPhi = theChosenPhoton->extras.full5x5_sigmaIPhiIPhi;
   photon_full5x5_r9 = theChosenPhoton->extras.full5x5_r9;
+  photon_r9 = theChosenPhoton->extras.r9;
   photon_seedTime = theChosenPhoton->extras.seedTime;
   photon_MIPTotalEnergy = theChosenPhoton->extras.MIPTotalEnergy;
 

--- a/AnalysisTree/test/produceSinglePhotonCR.cc
+++ b/AnalysisTree/test/produceSinglePhotonCR.cc
@@ -165,6 +165,7 @@ bool LooperFunctionHelpers::looperRule(BaseTreeLooper* theLooper, double const& 
   BRANCH_COMMAND(float, photon_full5x5_sigmaIEtaIEta) \
   BRANCH_COMMAND(float, photon_full5x5_sigmaIPhiIPhi) \
   BRANCH_COMMAND(float, photon_full5x5_r9) \
+  BRANCH_COMMAND(float, photon_r9) \
   BRANCH_COMMAND(float, photon_seedTime) \
   BRANCH_COMMAND(float, photon_MIPTotalEnergy) \
   BRANCH_COMMAND(bool, photon_is_genMatched_prompt) \
@@ -328,6 +329,7 @@ bool LooperFunctionHelpers::looperRule(BaseTreeLooper* theLooper, double const& 
   photon_full5x5_sigmaIEtaIEta = theChosenPhoton->extras.full5x5_sigmaIEtaIEta;
   photon_full5x5_sigmaIPhiIPhi = theChosenPhoton->extras.full5x5_sigmaIPhiIPhi;
   photon_full5x5_r9 = theChosenPhoton->extras.full5x5_r9;
+  photon_r9 = theChosenPhoton->extras.r9;
   photon_seedTime = theChosenPhoton->extras.seedTime;
   photon_MIPTotalEnergy = theChosenPhoton->extras.MIPTotalEnergy;
 


### PR DESCRIPTION
Please also include the 3x3 R9's since it is likely that the photon triggers actually use this.
there're 3 other branches I think is very necessary but I would leave the implementation to you:
- _event_run_, _event_lumi_, _event_event_

I would also separate the _event_wgt_pileup_ from the _event_wgt_, but I don't feel strong at this, as now we may have more confidence in the pileup weight now.

Otherwise I don't see any problem now, and let's start producing the skims!

